### PR TITLE
deploy/workload_identity.sh : Fix role creation and update README.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ As `autoneg` is accessing GCP APIs, you must ensure that the controller has auth
 
 First, set up the GCP resources necessary to support [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity), run the script:
 ```
-PROJECT=myproject deploy/workload_identity.sh
+PROJECT_ID=myproject deploy/workload_identity.sh
 ```
 Then, on each cluster in your project where you'd like to install `autoneg`, run these two commands:
 ```

--- a/deploy/workload_identity.sh
+++ b/deploy/workload_identity.sh
@@ -19,7 +19,7 @@ gcloud iam service-accounts add-iam-policy-binding \
   --member "serviceAccount:${PROJECT_ID}.svc.id.goog[autoneg-system/default]" \
   autoneg-system@${PROJECT_ID}.iam.gserviceaccount.com
 
-gcloud iam roles update autoneg --project ${PROJECT_ID} \
+gcloud iam roles create autoneg --project ${PROJECT_ID} \
   --permissions=compute.backendServices.get,compute.backendServices.update,compute.networkEndpointGroups.use,compute.healthChecks.useReadOnly
 gcloud projects add-iam-policy-binding \
   --role projects/${PROJECT_ID}/roles/autoneg \


### PR DESCRIPTION
Script fails updating a role that not exists

Fix for #17 and #8