### PR TITLE
retry update of service annotation on latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,7 @@ COPY go.sum go.sum
 RUN go mod download
 
 # Copy the go source
-COPY main.go main.go
-COPY api/ api/
-COPY controllers/ controllers/
+COPY . ./
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go

--- a/controllers/service_controller.go
+++ b/controllers/service_controller.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"encoding/json"
 	"reflect"
+	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -122,7 +124,8 @@ func (r *ServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	if err = r.Update(ctx, svc); err != nil {
 		r.Recorder.Event(svc, "Warning", "BackendError", err.Error())
-		return reconcile.Result{}, err
+		requeue := strings.Contains(err.Error(), "please apply your changes to the latest version and try again")
+		return reconcile.Result{Requeue: requeue, RequeueAfter: 10 * time.Second}, err
 	}
 
 	if deleting {


### PR DESCRIPTION
As the neg and autoneg controller are executing in parallel, the autoneg controller may be trying to update an old version of the service.  If this is the case, a retry is requested.