### PR TITLE
Adding non-root configuration to manifests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:latest
+FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --chown=nonroot:nonroot --from=builder /workspace/manager .
 USER nonroot

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
@@ -33,6 +33,9 @@ spec:
         ports:
         - containerPort: 8443
           name: https
+        securityContext:
+          privileged: false
+          allowPrivilegeEscalation: false
       - name: manager
         args:
         - "--metrics-addr=127.0.0.1:8080"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -36,6 +36,8 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      securityContext:
+        runAsNonRoot: true
       containers:
       - command:
         - /manager
@@ -50,4 +52,7 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          privileged: false
+          allowPrivilegeEscalation: false
       terminationGracePeriodSeconds: 10

--- a/deploy/autoneg.yaml
+++ b/deploy/autoneg.yaml
@@ -211,14 +211,22 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
       - args:
         - --secure-listen-address=0.0.0.0:8443
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443
           name: https
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+      securityContext:
+        runAsNonRoot: true
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Fixes #32 

Specifying runAsNonRoot at pod level, and privileged:false and
allowPrivilegeEscalation:false at container levels.

Added both to manage container, and kube-rbac-proxy container.

Updated kube-rbac-proxy dependency to 0.8.0, after support for non-root.