### PR TITLE
CI/CD pipeline

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,49 @@
+name: |
+  Build, test, push
+
+on:
+  push:
+    branches: 
+    - master
+  pull_request: 
+    
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
+
+    - name: Get version number
+      run: |
+        VERSION=$(grep 'const useragent' main.go | sed 's/.*\/\(.*\)"/\1/g')
+        if [ "$GITHUB_REF" != "refs/heads/master" ] ; then
+          PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
+          VERSION="${VERSION}-pr${PR_NUMBER}"
+        fi
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+    - name: Test
+      run: |
+        sudo mkdir -p /usr/local/kubebuilder
+        curl -Ls https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.2/kubebuilder_2.3.2_linux_amd64.tar.gz | sudo tar -xvz --strip-components=1 -C /usr/local/kubebuilder -f - 
+        make test
+
+    - name: Build image
+      run: |
+        make docker-build
+        
+    - name: Release image
+      run: |
+        make release-image
+      env:
+        RELEASE_IMAGE: ghcr.io/$GITHUB_REPOSITORY/gke-autoneg-controller/gke-autoneg-controller

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2019-2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.12.5 as builder
+FROM golang:1.16.5 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -25,7 +25,6 @@ RUN go mod download
 
 # Copy the go source
 COPY main.go main.go
-COPY api/ api/
 COPY controllers/ controllers/
 
 # Build


### PR DESCRIPTION
Added GitHub Actions based CI/CD pipeline for running tests, building containers and pushing them to `ghcr.io`. Also fixed an issue with the `Dockerfile`.