### PR TITLE
Generate backendservice name if not specified in autoneg annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In your GKE service, two annotations are required in your service definition:
 * `cloud.google.com/neg` enables the GKE NEG controller; specify as [standalone NEGs](https://cloud.google.com/kubernetes-engine/docs/how-to/standalone-neg)
 * `controller.autoneg.dev/neg` specifies name and other configuration
    * Previous version used `anthos.cft.dev/autoneg` as annotation and it's still supported, but deprecated and will be removed in subsequent releases.
-   * Note that `name` is optional here and defaults to a value generated following negNameTemplage. The template defaults to `{name}-{port}` and can be configured using `--neg-name-template` flag. It can contain `namespace`, `name`, `port` and `hash` and the non hash values will be truncated evenly if the full name is longer than 63 characters. `<hash>` is generated using full length `namespace`, `name` and `port` to avoid name collisions when truncated.
+   * Note that `name` is optional here and defaults to a value generated following serviceNameTemplate. The template defaults to `{name}-{port}` and can be configured using `--default-backendservice-name` flag. It can contain `namespace`, `name`, `port` and `hash` and the non hash values will be truncated evenly if the full name is longer than 63 characters. `<hash>` is generated using full length `namespace`, `name` and `port` to avoid name collisions when truncated.
 ```yaml
 metadata:
   annotations:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In your GKE service, two annotations are required in your service definition:
 * `cloud.google.com/neg` enables the GKE NEG controller; specify as [standalone NEGs](https://cloud.google.com/kubernetes-engine/docs/how-to/standalone-neg)
 * `controller.autoneg.dev/neg` specifies name and other configuration
    * Previous version used `anthos.cft.dev/autoneg` as annotation and it's still supported, but deprecated and will be removed in subsequent releases.
-   * Note that `name` is optional here and defaults to `<namespace>-<name>-<port>-<hash>`. `namespace`, `name` and `port` will be truncated evenly if the full name is longer than 63 characters. `<hash>` is generated using full length `namespace`, `name` and `port` to avoid name collision.
+   * Note that `name` is optional here and defaults to a value generated following negNameTemplage. The template defaults to `{name}-{port}` and can be configured using `--neg-name-template` flag. It can contain `namespace`, `name`, `port` and `hash` and the non hash values will be truncated evenly if the full name is longer than 63 characters. `<hash>` is generated using full length `namespace`, `name` and `port` to avoid name collisions when truncated.
 ```yaml
 metadata:
   annotations:
@@ -41,7 +41,7 @@ Specify options to configure the backends representing the NEGs that will be ass
 
 ### Options
 
-* `name`: optional. The name of the backend service to register backends with. Defaults to `<namespace>-<name>-<port>-<hash>`.
+* `name`: optional. The name of the backend service to register backends with. Defaults to a value generated using the given template.
    * The default name value for old `anthos.cft.dev/autoneg` annotation is service name.
 * `region`: optional. Used to specify that this is a regional backend service.
 * `max_rate_per_endpoint`: required/optional. Integer representing the maximum rate a pod can handle. Pick either rate or connection.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ In your GKE service, two annotations are required in your service definition:
 * `cloud.google.com/neg` enables the GKE NEG controller; specify as [standalone NEGs](https://cloud.google.com/kubernetes-engine/docs/how-to/standalone-neg)
 * `controller.autoneg.dev/neg` specifies name and other configuration
    * Previous version used `anthos.cft.dev/autoneg` as annotation and it's still supported, but deprecated and will be removed in subsequent releases.
+   * Note that `name` is optional here and defaults to `<namespace>-<name>-<port>-<hash>`. `namespace`, `name` and `port` will be truncated evenly if the full name is longer than 63 characters. `<hash>` is generated using full length `namespace`, `name` and `port` to avoid name collision.
 ```yaml
 metadata:
   annotations:
@@ -40,7 +41,8 @@ Specify options to configure the backends representing the NEGs that will be ass
 
 ### Options
 
-* `name`: optional. The name of the backend service to register backends with. Defaults to GKE service name.
+* `name`: optional. The name of the backend service to register backends with. Defaults to `<namespace>-<name>-<port>-<hash>`.
+   * The default name value for old `anthos.cft.dev/autoneg` annotation is service name.
 * `region`: optional. Used to specify that this is a regional backend service.
 * `max_rate_per_endpoint`: required/optional. Integer representing the maximum rate a pod can handle. Pick either rate or connection.
 * `max_connections_per_endpoint`: required/optional. Integer representing the maximum amount of connections a pod can handle. Pick either rate or connection.

--- a/controllers/autoneg.go
+++ b/controllers/autoneg.go
@@ -363,7 +363,7 @@ func validateNewConfig(cfg AutonegConfig) error {
 	return nil
 }
 
-func getStatuses(namespace string, name string, annotations map[string]string) (s Statuses, valid bool, err error) {
+func getStatuses(namespace string, name string, annotations map[string]string, negNameTemplate string) (s Statuses, valid bool, err error) {
 	// Read the current cloud.google.com/neg annotation
 	tmp, ok := annotations[negAnnotation]
 	if ok {
@@ -389,8 +389,8 @@ func getStatuses(namespace string, name string, annotations map[string]string) (
 			s.config.BackendServices[port] = make(map[string]AutonegNEGConfig, len(cfgs))
 			for _, cfg := range cfgs {
 				if cfg.Name == "" {
-					// Default to the k8s service name + port
-					cfg.Name = generateNegName(namespace, name, port)
+					// Default to name generated using negNameTemplate
+					cfg.Name = generateNegName(namespace, name, port, negNameTemplate)
 				}
 				s.config.BackendServices[port][cfg.Name] = cfg
 			}

--- a/controllers/autoneg.go
+++ b/controllers/autoneg.go
@@ -363,7 +363,7 @@ func validateNewConfig(cfg AutonegConfig) error {
 	return nil
 }
 
-func getStatuses(namespace string, name string, annotations map[string]string, negNameTemplate string) (s Statuses, valid bool, err error) {
+func getStatuses(namespace string, name string, annotations map[string]string, serviceNameTemplate string) (s Statuses, valid bool, err error) {
 	// Read the current cloud.google.com/neg annotation
 	tmp, ok := annotations[negAnnotation]
 	if ok {
@@ -389,8 +389,8 @@ func getStatuses(namespace string, name string, annotations map[string]string, n
 			s.config.BackendServices[port] = make(map[string]AutonegNEGConfig, len(cfgs))
 			for _, cfg := range cfgs {
 				if cfg.Name == "" {
-					// Default to name generated using negNameTemplate
-					cfg.Name = generateNegName(namespace, name, port, negNameTemplate)
+					// Default to name generated using serviceNameTemplate
+					cfg.Name = generateServiceName(namespace, name, port, serviceNameTemplate)
 				}
 				s.config.BackendServices[port][cfg.Name] = cfg
 			}

--- a/controllers/autoneg.go
+++ b/controllers/autoneg.go
@@ -363,7 +363,7 @@ func validateNewConfig(cfg AutonegConfig) error {
 	return nil
 }
 
-func getStatuses(name string, annotations map[string]string) (s Statuses, valid bool, err error) {
+func getStatuses(namespace string, name string, annotations map[string]string) (s Statuses, valid bool, err error) {
 	// Read the current cloud.google.com/neg annotation
 	tmp, ok := annotations[negAnnotation]
 	if ok {
@@ -390,7 +390,7 @@ func getStatuses(name string, annotations map[string]string) (s Statuses, valid 
 			for _, cfg := range cfgs {
 				if cfg.Name == "" {
 					// Default to the k8s service name + port
-					cfg.Name = fmt.Sprintf("%s-%s", name, port)
+					cfg.Name = generateNegName(namespace, name, port)
 				}
 				s.config.BackendServices[port][cfg.Name] = cfg
 			}

--- a/controllers/autoneg_test.go
+++ b/controllers/autoneg_test.go
@@ -209,7 +209,7 @@ var oldStatusTests = []struct {
 
 func TestGetStatuses(t *testing.T) {
 	for _, st := range statusTests {
-		_, valid, err := getStatuses("ns", "test", st.annotations)
+		_, valid, err := getStatuses("ns", "test", st.annotations, "{namespace}-{name}-{port}-{hash}")
 		if err != nil && !st.err {
 			t.Errorf("Set %q: expected no error, got one: %v", st.name, err)
 		}
@@ -227,7 +227,7 @@ func TestGetStatuses(t *testing.T) {
 
 func TestGetOldStatuses(t *testing.T) {
 	for _, st := range oldStatusTests {
-		_, valid, err := getStatuses("ns", "test", st.annotations)
+		_, valid, err := getStatuses("ns", "test", st.annotations, "{namespace}-{name}-{port}-{hash}")
 		if err != nil && !st.err {
 			t.Errorf("Set %q: expected no error, got one: %v", st.name, err)
 		}

--- a/controllers/autoneg_test.go
+++ b/controllers/autoneg_test.go
@@ -24,10 +24,11 @@ import (
 )
 
 var (
-	malformedJSON    = `{`
-	validConfig      = `{"backend_services":{"80":[{"name":"http-be","max_rate_per_endpoint":100}],"443":[{"name":"https-be","max_connections_per_endpoint":1000}]}}`
-	brokenConfig     = `{"backend_services":{"80":[{"name":"http-be","max_rate_per_endpoint":"100"}],"443":[{"name":"https-be","max_connections_per_endpoint":1000}}}`
-	validMultiConfig = `{"backend_services":{"80":[{"name":"http-be","max_rate_per_endpoint":100},{"name":"http-ilb-be","max_rate_per_endpoint":100}],"443":[{"name":"https-be","max_connections_per_endpoint":1000},{"name":"https-ilb-be","max_connections_per_endpoint":1000}]}}`
+	malformedJSON     = `{`
+	validConfig       = `{"backend_services":{"80":[{"name":"http-be","max_rate_per_endpoint":100}],"443":[{"name":"https-be","max_connections_per_endpoint":1000}]}}`
+	brokenConfig      = `{"backend_services":{"80":[{"name":"http-be","max_rate_per_endpoint":"100"}],"443":[{"name":"https-be","max_connections_per_endpoint":1000}}}`
+	validMultiConfig  = `{"backend_services":{"80":[{"name":"http-be","max_rate_per_endpoint":100},{"name":"http-ilb-be","max_rate_per_endpoint":100}],"443":[{"name":"https-be","max_connections_per_endpoint":1000},{"name":"https-ilb-be","max_connections_per_endpoint":1000}]}}`
+	validConfigWoName = `{"backend_services":{"80":[{"max_rate_per_endpoint":100}],"443":[{"max_connections_per_endpoint":1000}]}}`
 
 	validStatus        = `{}`
 	validAutonegConfig = `{}`
@@ -100,6 +101,15 @@ var statusTests = []struct {
 		"valid autoneg with valid neg status",
 		map[string]string{
 			autonegAnnotation:   validConfig,
+			negStatusAnnotation: validStatus,
+		},
+		true,
+		false,
+	},
+	{
+		"valid autoneg without neg name",
+		map[string]string{
+			autonegAnnotation:   validConfigWoName,
 			negStatusAnnotation: validStatus,
 		},
 		true,
@@ -199,7 +209,7 @@ var oldStatusTests = []struct {
 
 func TestGetStatuses(t *testing.T) {
 	for _, st := range statusTests {
-		_, valid, err := getStatuses("test", st.annotations)
+		_, valid, err := getStatuses("ns", "test", st.annotations)
 		if err != nil && !st.err {
 			t.Errorf("Set %q: expected no error, got one: %v", st.name, err)
 		}
@@ -217,7 +227,7 @@ func TestGetStatuses(t *testing.T) {
 
 func TestGetOldStatuses(t *testing.T) {
 	for _, st := range oldStatusTests {
-		_, valid, err := getStatuses("test", st.annotations)
+		_, valid, err := getStatuses("ns", "test", st.annotations)
 		if err != nil && !st.err {
 			t.Errorf("Set %q: expected no error, got one: %v", st.name, err)
 		}

--- a/controllers/service_controller.go
+++ b/controllers/service_controller.go
@@ -36,8 +36,9 @@ import (
 type ServiceReconciler struct {
 	client.Client
 	*BackendController
-	Recorder record.EventRecorder
-	Log      logr.Logger
+	Recorder        record.EventRecorder
+	Log             logr.Logger
+	NegNameTemplate string
 }
 
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;update;patch
@@ -59,7 +60,7 @@ func (r *ServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	status, ok, err := getStatuses(svc.Namespace, svc.Name, svc.ObjectMeta.Annotations)
+	status, ok, err := getStatuses(svc.Namespace, svc.Name, svc.ObjectMeta.Annotations, r.NegNameTemplate)
 	// Is this service using autoneg?
 	if !ok {
 		return reconcile.Result{}, nil

--- a/controllers/service_controller.go
+++ b/controllers/service_controller.go
@@ -36,9 +36,9 @@ import (
 type ServiceReconciler struct {
 	client.Client
 	*BackendController
-	Recorder        record.EventRecorder
-	Log             logr.Logger
-	NegNameTemplate string
+	Recorder            record.EventRecorder
+	Log                 logr.Logger
+	ServiceNameTemplate string
 }
 
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;update;patch
@@ -60,7 +60,7 @@ func (r *ServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	status, ok, err := getStatuses(svc.Namespace, svc.Name, svc.ObjectMeta.Annotations, r.NegNameTemplate)
+	status, ok, err := getStatuses(svc.Namespace, svc.Name, svc.ObjectMeta.Annotations, r.ServiceNameTemplate)
 	// Is this service using autoneg?
 	if !ok {
 		return reconcile.Result{}, nil

--- a/controllers/service_controller.go
+++ b/controllers/service_controller.go
@@ -59,7 +59,7 @@ func (r *ServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	status, ok, err := getStatuses(svc.Name, svc.ObjectMeta.Annotations)
+	status, ok, err := getStatuses(svc.Namespace, svc.Name, svc.ObjectMeta.Annotations)
 	// Is this service using autoneg?
 	if !ok {
 		return reconcile.Result{}, nil

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2019-2021 Google LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strings"
+)
+
+// maxNEGNameLength is the max length for namespace, name and
+// port for neg name.  63 - 8 (suffix hash) - 3 (hyphen connector) = 52
+var maxNEGNameLength = 52
+
+// NEG returns backend neg name based on the service namespace, name
+// and target port. NEG naming convention:
+//
+//   {namespace}-{name}-{service port}-{hash}
+//
+// Output name is at most 63 characters.
+func generateNegName(namespace string, name string, portStr string) string {
+	truncFields := TrimFieldsEvenly(maxNEGNameLength, namespace, name, portStr)
+	truncNamespace := truncFields[0]
+	truncName := truncFields[1]
+	truncPort := truncFields[2]
+	negString := strings.Join([]string{namespace, name, portStr}, "-")
+	negHash := fmt.Sprintf("%x", sha256.Sum256([]byte(negString)))
+	return fmt.Sprintf("%s-%s-%s-%s", truncNamespace, truncName, truncPort, negHash)
+}
+
+// This function is copied from:
+// https://github.com/kubernetes/ingress-gce/blob/4cb04408a6266b5ea00d9567c6165b9235392972/pkg/utils/namer/utils.go#L27..L62
+// TrimFieldsEvenly trims the fields evenly and keeps the total length
+// <= max. Truncation is spread in ratio with their original length,
+// meaning smaller fields will be truncated less than longer ones.
+func TrimFieldsEvenly(max int, fields ...string) []string {
+	if max <= 0 {
+		return fields
+	}
+	total := 0
+	for _, s := range fields {
+		total += len(s)
+	}
+	if total <= max {
+		return fields
+	}
+	// Distribute truncation evenly among the fields.
+	excess := total - max
+	remaining := max
+	var lengths []int
+	for _, s := range fields {
+		// Scale truncation to shorten longer fields more than ones that are already short.
+		l := len(s) - len(s)*excess/total - 1
+		lengths = append(lengths, l)
+		remaining -= l
+	}
+	// Add fractional space that was rounded down.
+	for i := 0; i < remaining; i++ {
+		lengths[i]++
+	}
+
+	var ret []string
+	for i, l := range lengths {
+		ret = append(ret, fields[i][:l])
+	}
+
+	return ret
+}

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2019-2021 Google LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"testing"
+)
+
+func TestNegNameGeneration(t *testing.T) {
+
+	negName := generateNegName("ns", "name", "8080")
+	expectedNegName := "ns-name-8080-" + hash("ns-name-8080")
+	if negName != expectedNegName {
+		t.Errorf("negName = %q, expect %q", negName, expectedNegName)
+	}
+}
+
+func TestLongNegNameGeneration(t *testing.T) {
+
+	negName := generateNegName("longlonglonglonglonglonglongnamespace", "longlonglongname", "8080")
+	expectedNegName := "longlonglonglonglonglonglongnamesp-longlonglongnam-808-" + hash("longlonglonglonglonglonglongnamespace-longlonglongname-8080")
+	if negName != expectedNegName {
+		t.Errorf("negName = %q, expect %q", negName, expectedNegName)
+	}
+}
+
+func TestLongNegNamesHaveDifferentHashes(t *testing.T) {
+
+	negName1 := generateNegName("longlonglonglonglonglonglongnamespace1", "longlonglongname", "8080")
+	negName2 := generateNegName("longlonglonglonglonglonglongnamespace2", "longlonglongname", "8080")
+	if negName1 == negName2 {
+		t.Errorf("negName1 should be different from negName2, but both are %q", negName1)
+	}
+}
+
+func hash(stringToHash string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(stringToHash)))
+}

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -22,9 +22,11 @@ import (
 	"testing"
 )
 
+var negNameTemplate = "{namespace}-{name}-{port}-{hash}"
+
 func TestNegNameGeneration(t *testing.T) {
 
-	negName := generateNegName("ns", "name", "8080")
+	negName := generateNegName("ns", "name", "8080", negNameTemplate)
 	expectedNegName := "ns-name-8080-" + hash("ns-name-8080")
 	if negName != expectedNegName {
 		t.Errorf("negName = %q, expect %q", negName, expectedNegName)
@@ -33,22 +35,74 @@ func TestNegNameGeneration(t *testing.T) {
 
 func TestLongNegNameGeneration(t *testing.T) {
 
-	negName := generateNegName("longlonglonglonglonglonglongnamespace", "longlonglongname", "8080")
+	negName := generateNegName("longlonglonglonglonglonglongnamespace", "longlonglongname", "8080", negNameTemplate)
 	expectedNegName := "longlonglonglonglonglonglongnamesp-longlonglongnam-808-" + hash("longlonglonglonglonglonglongnamespace-longlonglongname-8080")
 	if negName != expectedNegName {
 		t.Errorf("negName = %q, expect %q", negName, expectedNegName)
+	}
+	if len(negName) != 63 {
+		t.Errorf("max neg name length should be 63 but is %q", len(negName))
 	}
 }
 
 func TestLongNegNamesHaveDifferentHashes(t *testing.T) {
 
-	negName1 := generateNegName("longlonglonglonglonglonglongnamespace1", "longlonglongname", "8080")
-	negName2 := generateNegName("longlonglonglonglonglonglongnamespace2", "longlonglongname", "8080")
+	negName1 := generateNegName("longlonglonglonglonglonglongnamespace1", "longlonglongname", "8080", negNameTemplate)
+	negName2 := generateNegName("longlonglonglonglonglonglongnamespace2", "longlonglongname", "8080", negNameTemplate)
 	if negName1 == negName2 {
 		t.Errorf("negName1 should be different from negName2, but both are %q", negName1)
 	}
 }
 
+func TestValidNegTemplate(t *testing.T) {
+	validTemplates := []string{"{namespace}", "{name}", "{port}", "{hash}", "{name}-{port}", "{namespace}-{name}-{port}-{hash}"}
+	for _, template := range validTemplates {
+		if !IsValidNEGTemplate(template) {
+			t.Errorf("Template %q should be valid but is considered invalid", template)
+		}
+	}
+}
+
+func TestInvalidNegTemplate(t *testing.T) {
+	invalidTemplates := []string{"{namespace", "", "-", "{has}", "{name}--{port}", "{namespace};{name};{port};{hash}"}
+	for _, template := range invalidTemplates {
+		if IsValidNEGTemplate(template) {
+			t.Errorf("Template %q should be invalid but is considered valid", template)
+		}
+	}
+}
+
+func TestLongNegGenerationWithoutHash(t *testing.T) {
+	negName := generateNegName("longlonglonglonglonglonglongnamespace", "longlonglonglonglonglongname", "8080", "{namespace}-{name}-{port}")
+	expectedNegName := "longlonglonglonglonglonglongnames-longlonglonglonglonglongn-808"
+	if negName != expectedNegName {
+		t.Errorf("negName = %q, expect %q", negName, expectedNegName)
+	}
+	if len(negName) != 63 {
+		t.Errorf("max neg name length should be 63 but is %q", len(negName))
+	}
+}
+
+func TestLongNegGenerationWithMultipleHashes(t *testing.T) {
+	negName := generateNegName("longlonglonglongnamespace", "longlonglongname", "8080", "{hash}-{namespace}-{name}-{port}-{hash}")
+	hash := hash("longlonglonglongnamespace-longlonglongname-8080")
+	expectedNegName := hash + "-longlonglonglongnamespac-longlonglongname-808-" + hash
+	if negName != expectedNegName {
+		t.Errorf("negName = %q, expect %q", negName, expectedNegName)
+	}
+	if len(negName) != 63 {
+		t.Errorf("max neg name length should be 63 but is %q", len(negName))
+	}
+}
+
+func TestNegGenerationWithoutHash(t *testing.T) {
+	negName := generateNegName("namespace", "name", "8080", "{name}-{port}")
+	expectedNegName := "name-8080"
+	if negName != expectedNegName {
+		t.Errorf("negName = %q, expect %q", negName, expectedNegName)
+	}
+}
+
 func hash(stringToHash string) string {
-	return fmt.Sprintf("%x", sha256.Sum256([]byte(stringToHash)))
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(stringToHash)))[:8]
 }

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -22,84 +22,84 @@ import (
 	"testing"
 )
 
-var negNameTemplate = "{namespace}-{name}-{port}-{hash}"
+var serviceNameTemplate = "{namespace}-{name}-{port}-{hash}"
 
-func TestNegNameGeneration(t *testing.T) {
+func TestServiceNameGeneration(t *testing.T) {
 
-	negName := generateNegName("ns", "name", "8080", negNameTemplate)
-	expectedNegName := "ns-name-8080-" + hash("ns-name-8080")
-	if negName != expectedNegName {
-		t.Errorf("negName = %q, expect %q", negName, expectedNegName)
+	serviceName := generateServiceName("ns", "name", "8080", serviceNameTemplate)
+	expectedServiceName := "ns-name-8080-" + hash("ns-name-8080")
+	if serviceName != expectedServiceName {
+		t.Errorf("serviceName = %q, expect %q", serviceName, expectedServiceName)
 	}
 }
 
-func TestLongNegNameGeneration(t *testing.T) {
+func TestLongServiceNameGeneration(t *testing.T) {
 
-	negName := generateNegName("longlonglonglonglonglonglongnamespace", "longlonglongname", "8080", negNameTemplate)
-	expectedNegName := "longlonglonglonglonglonglongnamesp-longlonglongnam-808-" + hash("longlonglonglonglonglonglongnamespace-longlonglongname-8080")
-	if negName != expectedNegName {
-		t.Errorf("negName = %q, expect %q", negName, expectedNegName)
+	serviceName := generateServiceName("longlonglonglonglonglonglongnamespace", "longlonglongname", "8080", serviceNameTemplate)
+	expectedServiceName := "longlonglonglonglonglonglongnamesp-longlonglongnam-808-" + hash("longlonglonglonglonglonglongnamespace-longlonglongname-8080")
+	if serviceName != expectedServiceName {
+		t.Errorf("serviceName = %q, expect %q", serviceName, expectedServiceName)
 	}
-	if len(negName) != 63 {
-		t.Errorf("max neg name length should be 63 but is %q", len(negName))
-	}
-}
-
-func TestLongNegNamesHaveDifferentHashes(t *testing.T) {
-
-	negName1 := generateNegName("longlonglonglonglonglonglongnamespace1", "longlonglongname", "8080", negNameTemplate)
-	negName2 := generateNegName("longlonglonglonglonglonglongnamespace2", "longlonglongname", "8080", negNameTemplate)
-	if negName1 == negName2 {
-		t.Errorf("negName1 should be different from negName2, but both are %q", negName1)
+	if len(serviceName) != 63 {
+		t.Errorf("max service name length should be 63 but is %q", len(serviceName))
 	}
 }
 
-func TestValidNegTemplate(t *testing.T) {
+func TestLongServiceNamesHaveDifferentHashes(t *testing.T) {
+
+	serviceName1 := generateServiceName("longlonglonglonglonglonglongnamespace1", "longlonglongname", "8080", serviceNameTemplate)
+	serviceName2 := generateServiceName("longlonglonglonglonglonglongnamespace2", "longlonglongname", "8080", serviceNameTemplate)
+	if serviceName1 == serviceName2 {
+		t.Errorf("serviceName1 should be different from serviceName2, but both are %q", serviceName1)
+	}
+}
+
+func TestValidServiceTemplate(t *testing.T) {
 	validTemplates := []string{"{namespace}", "{name}", "{port}", "{hash}", "{name}-{port}", "{namespace}-{name}-{port}-{hash}"}
 	for _, template := range validTemplates {
-		if !IsValidNEGTemplate(template) {
+		if !IsValidServiceNameTemplate(template) {
 			t.Errorf("Template %q should be valid but is considered invalid", template)
 		}
 	}
 }
 
-func TestInvalidNegTemplate(t *testing.T) {
+func TestInvalidServiceTemplate(t *testing.T) {
 	invalidTemplates := []string{"{namespace", "", "-", "{has}", "{name}--{port}", "{namespace};{name};{port};{hash}"}
 	for _, template := range invalidTemplates {
-		if IsValidNEGTemplate(template) {
+		if IsValidServiceNameTemplate(template) {
 			t.Errorf("Template %q should be invalid but is considered valid", template)
 		}
 	}
 }
 
-func TestLongNegGenerationWithoutHash(t *testing.T) {
-	negName := generateNegName("longlonglonglonglonglonglongnamespace", "longlonglonglonglonglongname", "8080", "{namespace}-{name}-{port}")
-	expectedNegName := "longlonglonglonglonglonglongnames-longlonglonglonglonglongn-808"
-	if negName != expectedNegName {
-		t.Errorf("negName = %q, expect %q", negName, expectedNegName)
+func TestLongServiceGenerationWithoutHash(t *testing.T) {
+	serviceName := generateServiceName("longlonglonglonglonglonglongnamespace", "longlonglonglonglonglongname", "8080", "{namespace}-{name}-{port}")
+	expectedServiceName := "longlonglonglonglonglonglongnames-longlonglonglonglonglongn-808"
+	if serviceName != expectedServiceName {
+		t.Errorf("serviceName = %q, expect %q", serviceName, expectedServiceName)
 	}
-	if len(negName) != 63 {
-		t.Errorf("max neg name length should be 63 but is %q", len(negName))
+	if len(serviceName) != 63 {
+		t.Errorf("max service name length should be 63 but is %q", len(serviceName))
 	}
 }
 
-func TestLongNegGenerationWithMultipleHashes(t *testing.T) {
-	negName := generateNegName("longlonglonglongnamespace", "longlonglongname", "8080", "{hash}-{namespace}-{name}-{port}-{hash}")
+func TestLongServiceGenerationWithMultipleHashes(t *testing.T) {
+	serviceName := generateServiceName("longlonglonglongnamespace", "longlonglongname", "8080", "{hash}-{namespace}-{name}-{port}-{hash}")
 	hash := hash("longlonglonglongnamespace-longlonglongname-8080")
-	expectedNegName := hash + "-longlonglonglongnamespac-longlonglongname-808-" + hash
-	if negName != expectedNegName {
-		t.Errorf("negName = %q, expect %q", negName, expectedNegName)
+	expectedServiceName := hash + "-longlonglonglongnamespac-longlonglongname-808-" + hash
+	if serviceName != expectedServiceName {
+		t.Errorf("serviceName = %q, expect %q", serviceName, expectedServiceName)
 	}
-	if len(negName) != 63 {
-		t.Errorf("max neg name length should be 63 but is %q", len(negName))
+	if len(serviceName) != 63 {
+		t.Errorf("max service name length should be 63 but is %q", len(serviceName))
 	}
 }
 
-func TestNegGenerationWithoutHash(t *testing.T) {
-	negName := generateNegName("namespace", "name", "8080", "{name}-{port}")
-	expectedNegName := "name-8080"
-	if negName != expectedNegName {
-		t.Errorf("negName = %q, expect %q", negName, expectedNegName)
+func TestServiceGenerationWithoutHash(t *testing.T) {
+	serviceName := generateServiceName("namespace", "name", "8080", "{name}-{port}")
+	expectedServiceName := "name-8080"
+	if serviceName != expectedServiceName {
+		t.Errorf("serviceName = %q, expect %q", serviceName, expectedServiceName)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -18,7 +18,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
+	"fmt"
 	"os"
 
 	"cloud.google.com/go/compute/metadata"
@@ -51,9 +53,13 @@ func init() {
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
+	var negNameTemplate string
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&negNameTemplate, "neg-name-template", "{name}-{port}",
+		"A naming template consists of {namespace}, {name}, {port} or {hash} separated by hyphens, "+
+			"where {hash} is the first 8 digits of a hash of other given information")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.Logger(true))
@@ -73,6 +79,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	if !controllers.IsValidNEGTemplate(negNameTemplate) {
+		err = errors.New(fmt.Sprintf("invlaid neg name template %s", negNameTemplate))
+		setupLog.Error(err, "invalid neg name template")
+		os.Exit(1)
+	}
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,
@@ -88,6 +100,7 @@ func main() {
 		BackendController: controllers.NewBackendController(project, s),
 		Recorder:          mgr.GetEventRecorderFor("autoneg-controller"),
 		Log:               ctrl.Log.WithName("controllers").WithName("Service"),
+		NegNameTemplate:   negNameTemplate,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Service")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ func main() {
 	}
 
 	if !controllers.IsValidServiceNameTemplate(serviceNameTemplate) {
-		err = fmt.Errorf("invlaid service name template %s", serviceNameTemplate)
+		err = fmt.Errorf("invalid service name template %s", serviceNameTemplate)
 		setupLog.Error(err, "invalid service name template")
 		os.Exit(1)
 	}


### PR DESCRIPTION
### Why

We (Fabric/Spotify) would like to use autoneg without specifying neg names and realized that the default values might be a bit simple and prone to name collisions. Currently the NEG name defaults to `service name + port` when using new autoneg annotation and `service name` when using old config, in this PR we propose to change it to generated name similar to [how `k8s-io/ingress-gce` generates NEG names](https://github.com/kubernetes/ingress-gce/blob/4cb04408a6266b5ea00d9567c6165b9235392972/pkg/utils/namer/namer.go#L431-L449).

### What
- Allows passing a NEG name template using `--neg-name-template` flag, and defaults to `{name}-{port}`
- If NEG name is not set in the new autoneg annotation, generate one using the given template
  - Generated name may contain `namespace`, `name`, `port` or the first 8 characters of a sha256 hash, separated with `-`. It has max length of 63 characters, the non-hash tags are truncated evenly if the full name is longer than that. The hash can be used to make sure truncated long names won't collide.
  - The name generation is only applied to the new neg annotation as `port` mapping is missing with the old annotation.