### PR TITLE
Add flag to disallow name overwrites in autoneg annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Specify options to configure the backends representing the NEGs that will be ass
 ### Options
 
 * `name`: optional. The name of the backend service to register backends with. Defaults to a value generated using the given template.
-   * If `--allow-service-name` flag (defaults to `true`) is set to `false`, the `name` values specified in new autoneg annotations would be invalidated and fall back to the template generated names.
+   * If `--enable-supplied-service-names` flag (defaults to `true`) is set to `false`, the `name` values specified in new autoneg annotations would be invalidated and fall back to the template generated names.
    * The default name value for old `anthos.cft.dev/autoneg` annotation is service name.
 * `region`: optional. Used to specify that this is a regional backend service.
 * `max_rate_per_endpoint`: required/optional. Integer representing the maximum rate a pod can handle. Pick either rate or connection.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Specify options to configure the backends representing the NEGs that will be ass
 ### Options
 
 * `name`: optional. The name of the backend service to register backends with. Defaults to a value generated using the given template.
-   * If `--enable-supplied-service-names` flag (defaults to `true`) is set to `false`, the `name` values specified in new autoneg annotations would be invalidated and fall back to the template generated names.
+   * If `--enable-custom-service-names` flag (defaults to `true`) is set to `false`, the `name` values specified in new autoneg annotations would be invalidated and fall back to the template generated names.
    * The default name value for old `anthos.cft.dev/autoneg` annotation is service name.
 * `region`: optional. Used to specify that this is a regional backend service.
 * `max_rate_per_endpoint`: required/optional. Integer representing the maximum rate a pod can handle. Pick either rate or connection.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Specify options to configure the backends representing the NEGs that will be ass
 ### Options
 
 * `name`: optional. The name of the backend service to register backends with. Defaults to a value generated using the given template.
+   * If `--allow-service-name` flag (defaults to `true`) is set to `false`, the `name` values specified in new autoneg annotations would be invalidated and fall back to the template generated names.
    * The default name value for old `anthos.cft.dev/autoneg` annotation is service name.
 * `region`: optional. Used to specify that this is a regional backend service.
 * `max_rate_per_endpoint`: required/optional. Integer representing the maximum rate a pod can handle. Pick either rate or connection.

--- a/controllers/autoneg.go
+++ b/controllers/autoneg.go
@@ -363,7 +363,7 @@ func validateNewConfig(cfg AutonegConfig) error {
 	return nil
 }
 
-func getStatuses(namespace string, name string, annotations map[string]string, serviceNameTemplate string) (s Statuses, valid bool, err error) {
+func getStatuses(namespace string, name string, annotations map[string]string, serviceNameTemplate string, allowServiceName bool) (s Statuses, valid bool, err error) {
 	// Read the current cloud.google.com/neg annotation
 	tmp, ok := annotations[negAnnotation]
 	if ok {
@@ -388,7 +388,7 @@ func getStatuses(namespace string, name string, annotations map[string]string, s
 		for port, cfgs := range tempConfig.BackendServices {
 			s.config.BackendServices[port] = make(map[string]AutonegNEGConfig, len(cfgs))
 			for _, cfg := range cfgs {
-				if cfg.Name == "" {
+				if cfg.Name == "" || !allowServiceName {
 					// Default to name generated using serviceNameTemplate
 					cfg.Name = generateServiceName(namespace, name, port, serviceNameTemplate)
 				}

--- a/controllers/service_controller.go
+++ b/controllers/service_controller.go
@@ -39,6 +39,7 @@ type ServiceReconciler struct {
 	Recorder            record.EventRecorder
 	Log                 logr.Logger
 	ServiceNameTemplate string
+	AllowServiceName    bool
 }
 
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;update;patch
@@ -60,7 +61,7 @@ func (r *ServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	status, ok, err := getStatuses(svc.Namespace, svc.Name, svc.ObjectMeta.Annotations, r.ServiceNameTemplate)
+	status, ok, err := getStatuses(svc.Namespace, svc.Name, svc.ObjectMeta.Annotations, r.ServiceNameTemplate, r.AllowServiceName)
 	// Is this service using autoneg?
 	if !ok {
 		return reconcile.Result{}, nil

--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ func main() {
 	flag.StringVar(&serviceNameTemplate, "default-backendservice-name", "{name}-{port}",
 		"A naming template consists of {namespace}, {name}, {port} or {hash} separated by hyphens, "+
 			"where {hash} is the first 8 digits of a hash of other given information")
-	flag.BoolVar(&allowServiceName, "allow-service-name", true, "Enable setting custom service name in autoneg annotation.")
+	flag.BoolVar(&allowServiceName, "enable-supplied-service-names", true, "Enable using custom service names in autoneg annotation.")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.Logger(true))

--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ func main() {
 	flag.StringVar(&serviceNameTemplate, "default-backendservice-name", "{name}-{port}",
 		"A naming template consists of {namespace}, {name}, {port} or {hash} separated by hyphens, "+
 			"where {hash} is the first 8 digits of a hash of other given information")
-	flag.BoolVar(&allowServiceName, "enable-supplied-service-names", true, "Enable using custom service names in autoneg annotation.")
+	flag.BoolVar(&allowServiceName, "enable-custom-service-names", true, "Enable using custom service names in autoneg annotation.")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.Logger(true))

--- a/main.go
+++ b/main.go
@@ -53,12 +53,14 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var serviceNameTemplate string
+	var allowServiceName bool
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&serviceNameTemplate, "default-backendservice-name", "{name}-{port}",
 		"A naming template consists of {namespace}, {name}, {port} or {hash} separated by hyphens, "+
 			"where {hash} is the first 8 digits of a hash of other given information")
+	flag.BoolVar(&allowServiceName, "allow-service-name", true, "Enable setting custom service name in autoneg annotation.")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.Logger(true))
@@ -100,6 +102,7 @@ func main() {
 		Recorder:            mgr.GetEventRecorderFor("autoneg-controller"),
 		Log:                 ctrl.Log.WithName("controllers").WithName("Service"),
 		ServiceNameTemplate: serviceNameTemplate,
+		AllowServiceName:    allowServiceName,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Service")
 		os.Exit(1)


### PR DESCRIPTION
This PR follows up on https://github.com/GoogleCloudPlatform/gke-autoneg-controller/pull/44
We (Spotify) would like to only use generated backend service names and disallow users from setting custom service names in annotations to prevent name collision of services. 