### PR TITLE
deploy: add custom service account

### DIFF
--- a/deploy/autoneg.yaml
+++ b/deploy/autoneg.yaml
@@ -20,6 +20,12 @@ metadata:
     control-plane: controller-manager
   name: autoneg-system
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: autoneg
+  namespace: autoneg-system
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -229,4 +235,5 @@ spec:
           privileged: false
       securityContext:
         runAsNonRoot: true
+      serviceAccountName: autoneg
       terminationGracePeriodSeconds: 10

--- a/deploy/workload_identity.sh
+++ b/deploy/workload_identity.sh
@@ -16,7 +16,7 @@
 gcloud iam service-accounts create autoneg-system --display-name "autoneg"
 gcloud iam service-accounts add-iam-policy-binding \
   --role roles/iam.workloadIdentityUser \
-  --member "serviceAccount:${PROJECT_ID}.svc.id.goog[autoneg-system/default]" \
+  --member "serviceAccount:${PROJECT_ID}.svc.id.goog[autoneg-system/autoneg]" \
   autoneg-system@${PROJECT_ID}.iam.gserviceaccount.com
 
 gcloud iam roles create autoneg --project ${PROJECT_ID} \


### PR DESCRIPTION
Adding a specific account to the manifests eases the process of patching
them using tools like Kustomize.

This way it would be easy to do the following:

`kustomization.yaml`:
```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
resources:
  - https://raw.githubusercontent.com/GoogleCloudPlatform/gke-autoneg-controller/v0.9.5/deploy/autoneg.yaml
patches:
- patch: |-
    - op: replace
      path: "/metadata/annotations/iam.gke.io~1gcp-service-account"
      value: autoneg-system@{project-id}.iam.gserviceaccount.com
  target:
    kind: ServiceAccount
```