### PR TITLE
Make gcp terraform module more configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@ bin
 *.swp
 *.swo
 *~
+
+# terraform
+**/.terraform/*
+*.tfvars
+*.tfstate
+*.tfstate.*

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -23,39 +23,52 @@ terraform {
 }
 
 resource "google_service_account" "autoneg" {
+  project    = var.project_id
+  account_id = var.service_account_id
+}
+
+resource "google_compute_subnetwork_iam_member" "shared_vpc_user" {
+  count      = var.shared_vpc != null ? 1 : 0
+  project    = var.shared_vpc.project_id
+  region     = var.shared_vpc.subnetwork_region
+  subnetwork = var.shared_vpc.subnetwork_id
+  role       = "roles/compute.networkUser"
+  member     = "serviceAccount:${google_service_account.autoneg.email}"
+}
+
+locals {
+  zonal_permissions = [
+    "compute.backendServices.get",
+    "compute.backendServices.update",
+    "compute.networkEndpointGroups.use",
+    "compute.healthChecks.useReadOnly",
+  ]
+  permissions = var.regional ? concat(
+    local.zonal_permissions, [
+      "compute.regionBackendServices.get",
+      "compute.regionBackendServices.update",
+      "compute.regionHealthChecks.useReadOnly",
+    ],
+  ) : local.zonal_permissions
+}
+
+resource "google_project_iam_custom_role" "autoneg" {
+  project     = var.project_id
+  role_id     = var.regional ? "autonegRegional" : "autonegZonal"
+  title       = "${var.regional ? "Regional" : "Zonal"} AutoNEG role"
+  description = "Minimum viable IAM custom role to allow AutoNEG to watch and associate NEGs created by the NEG controller to backend services"
+  permissions = local.permissions
+}
+
+resource "google_project_iam_member" "autoneg" {
   project = var.project_id
-
-  account_id   = "autoneg"
-  display_name = "Autoneg service account"
+  role    = google_project_iam_custom_role.autoneg.id
+  member  = "serviceAccount:${google_service_account.autoneg.email}"
 }
 
-resource "google_project_iam_custom_role" "autoneg_role" {
-  project = var.project_id
-
-  role_id     = "autoneg"
-  title       = "Autoneg role"
-  description = "Autoneg role"
-  permissions = ["compute.backendServices.get", "compute.backendServices.update", "compute.regionBackendServices.get", "compute.regionBackendServices.update", "compute.networkEndpointGroups.use", "compute.healthChecks.useReadOnly", "compute.regionHealthChecks.useReadOnly"]
-}
-
-data "google_iam_policy" "autoneg_iam_policy" {
-  binding {
-    role = "roles/iam.workloadIdentityUser"
-
-    members = [
-      format("serviceAccount:%s.svc.id.goog[autoneg-system/autoneg]", var.project_id)
-    ]
-  }
-}
-
-resource "google_service_account_iam_policy" "autoneg_sa_iam" {
+resource "google_service_account_iam_member" "workload_identity" {
+  count              = var.workload_identity != null ? 1 : 0
   service_account_id = google_service_account.autoneg.name
-  policy_data        = data.google_iam_policy.autoneg_iam_policy.policy_data
-}
-
-resource "google_project_iam_member" "autoneg_iam" {
-  project = var.project_id
-
-  role   = google_project_iam_custom_role.autoneg_role.id
-  member = format("serviceAccount:%s", google_service_account.autoneg.email)
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[${var.workload_identity.namespace}/${var.workload_identity.service_account}]"
 }

--- a/terraform/gcp/outputs.tf
+++ b/terraform/gcp/outputs.tf
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+output "service_account_email" {
+  value = google_service_account.autoneg.email
+}
 
 output "service_account" {
   value = google_service_account.autoneg

--- a/terraform/gcp/outputs.tf
+++ b/terraform/gcp/outputs.tf
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
-output "service_account_email" {
-  value = google_service_account.autoneg.email
+output "service_account" {
+  value = google_service_account.autoneg
+}
+
+output "autoneg_custom_role" {
+  value = google_project_iam_custom_role.autoneg
 }

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -18,3 +18,34 @@ variable "project_id" {
   type        = string
   description = "GCP project ID"
 }
+
+variable "service_account_id" {
+  description = "Service account id to be created"
+  default     = "autoneg"
+  type        = string
+}
+
+variable "shared_vpc" {
+  description = "Shared VPC configuration which the autoneg service account can use"
+  default     = null
+  type = object({
+    project_id        = string
+    subnetwork_region = string
+    subnetwork_id     = string
+  })
+}
+
+variable "workload_identity" {
+  description = "Workload identity configuration"
+  default     = null
+  type = object({
+    namespace       = string
+    service_account = string
+  })
+}
+
+variable "regional" {
+  description = "Whether or not to add regionBackend and regionHealthCheck permissions."
+  default     = true
+  type        = bool
+}


### PR DESCRIPTION
These changes should make the terraform module more flexible for general use cases (e.g. GKE cluster project is in a shared VPC).

Summary of changes:
+ service account name configuration
+ shared VPC access configuration
+ workload identity configuration
+ limit autoneg role to zonal or regional permissions 
