### PR TITLE
Use kubernetes service account in rolebindings

### DIFF
--- a/deploy/autoneg.yaml
+++ b/deploy/autoneg.yaml
@@ -128,7 +128,7 @@ roleRef:
   name: autoneg-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: autoneg
   namespace: autoneg-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -143,7 +143,7 @@ roleRef:
   name: autoneg-manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: autoneg
   namespace: autoneg-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -158,7 +158,7 @@ roleRef:
   name: autoneg-proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: autoneg
   namespace: autoneg-system
 ---
 apiVersion: v1


### PR DESCRIPTION
The yaml creates a service account but it binds to default instead. This PR will allow the Kubernetes service account created above to be used in the role bindings