### PR TITLE
Kubernetes role bindings should use serviceaccount

### DIFF
--- a/deploy/autoneg.yaml
+++ b/deploy/autoneg.yaml
@@ -128,7 +128,7 @@ roleRef:
   name: autoneg-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: autoneg
   namespace: autoneg-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -143,7 +143,7 @@ roleRef:
   name: autoneg-manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: autoneg
   namespace: autoneg-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -158,7 +158,7 @@ roleRef:
   name: autoneg-proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: autoneg
   namespace: autoneg-system
 ---
 apiVersion: v1


### PR DESCRIPTION
Kubernetes Service account is not being used by the role bindings