### PR TITLE
Fix readme to annotate autoneg service account

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Lastly, on each cluster in your project where you'd like to install `autoneg` (v
 ```
 kubectl apply -f deploy/autoneg.yaml
 
-kubectl annotate sa -n autoneg-system default \
+kubectl annotate sa -n autoneg-system autoneg \
   iam.gke.io/gcp-service-account=autoneg-system@${PROJECT_ID}.iam.gserviceaccount.com
 ```
 This will create all the Kubernetes resources required to support `autoneg` and annotate the default service account in the `autoneg-system` namespace to associate a GCP service account using [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity). 


### PR DESCRIPTION
Update the installation step to add an annotation to configure the cluster side of workload identity. The installation step adds an annotation to the `default` service account in the `autoneg-system` namespace. Since the autoneg-controller-manager deployment [uses the service account `autoneg`](https://github.com/GoogleCloudPlatform/gke-autoneg-controller/blob/master/deploy/autoneg.yaml#L238), the annotation should be on `autoneg`.

Fixes #65
