### PR TITLE
Be able to use a random suffix on custom role name

### DIFF
--- a/terraform/autoneg/main.tf
+++ b/terraform/autoneg/main.tf
@@ -30,6 +30,8 @@ module "gcp" {
 
   project_id = var.project_id
 
+  custom_role_add_random_suffix = var.custom_role_add_random_suffix
+
   workload_identity = var.workload_identity
 }
 

--- a/terraform/autoneg/variables.tf
+++ b/terraform/autoneg/variables.tf
@@ -48,3 +48,9 @@ variable "workload_identity" {
     service_account = "autoneg"
   }
 }
+
+variable "custom_role_add_random_suffix" {
+  type        = bool
+  description = "Sets random suffix at the end of the IAM custom role id"
+  default     = false
+}

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -54,9 +54,16 @@ locals {
   ) : local.zonal_permissions
 }
 
+resource "random_string" "suffix" {
+  count = var.custom_role_add_random_suffix ? 1 : 0
+
+  length  = 4
+  special = false
+}
+
 resource "google_project_iam_custom_role" "autoneg" {
   project     = var.project_id
-  role_id     = var.regional ? "autonegRegional" : "autonegZonal"
+  role_id     = "autoneg${var.regional ? "Regional" : "Zonal"}${var.custom_role_add_random_suffix ? random_string.suffix[0].result : ""}"
   title       = "${var.regional ? "Regional" : "Zonal"} AutoNEG role"
   description = "Minimum viable IAM custom role to allow AutoNEG to watch and associate NEGs created by the NEG controller to backend services"
   permissions = local.permissions

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -52,3 +52,9 @@ variable "regional" {
   default     = true
   type        = bool
 }
+
+variable "custom_role_add_random_suffix" {
+  type        = bool
+  description = "Sets random suffix at the end of the IAM custom role id"
+  default     = false
+}


### PR DESCRIPTION
Due to a GCP limitation, custom role names are reserved for up to 37 days as described in their documentation:

> Note that custom roles in GCP have the concept of a soft-delete. There are two issues that may arise from this and how roles are propagated. 1) creating a role may involve undeleting and then updating a role with the same name, possibly causing confusing behavior between undelete and update. 2) A deleted role is permanently deleted after 7 days, but it can take up to 30 more days (i.e. between 7 and 37 days after deletion) before the role name is made available again. This means a deleted role that has been deleted for more than 7 days cannot be changed at all by Terraform, and new roles cannot share that name.

Closes #71 

Signed-off-by: Ferran Vidal <ferran.vidal.p@gmail.com>