### PR TITLE
[WIP] Do not block deletion if NEG status is empty

### DIFF
--- a/controllers/service_controller.go
+++ b/controllers/service_controller.go
@@ -93,7 +93,7 @@ func (r *ServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		intendedStatus.NEGStatus = NEGStatus{}
 	}
 
-	if reflect.DeepEqual(status.status, intendedStatus) {
+	if reflect.DeepEqual(status.status, intendedStatus) && !deleting {
 		// Equal, no reconciliation necessary
 		return reconcile.Result{}, nil
 	}
@@ -177,9 +177,7 @@ func (r *ServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-//
 // Helper functions to check and remove string from a slice of strings.
-//
 func containsString(slice []string, s string) bool {
 	for _, item := range slice {
 		if item == s {


### PR DESCRIPTION
Fix a bug where an empty `cloud.google.com/neg-status` blocks deletion of the service resource.

To reproduce the bug:
- create a new service.yaml with autoneg annotations pointing to an invalid port
- try removing the service resource manually, the deletion hangs
- the deletion completes if we patch the resource with `finalizers:null`

TODO: add a test