### PR TITLE
fix: Update the version of the controller image tag to 0.9.9

### DIFF
--- a/terraform/autoneg/variables.tf
+++ b/terraform/autoneg/variables.tf
@@ -22,7 +22,7 @@ variable "project_id" {
 variable "controller_image" {
   type        = string
   description = "Autoneg controller container image"
-  default     = "ghcr.io/googlecloudplatform/gke-autoneg-controller/gke-autoneg-controller:v0.9.7"
+  default     = "ghcr.io/googlecloudplatform/gke-autoneg-controller/gke-autoneg-controller:v0.9.9"
 }
 
 variable "image_pull_policy" {


### PR DESCRIPTION
Updated the version of the image deployed through the terraform resource. 
Used to be v0.9.7 with outdated arguments that are available in v0.9.8