### PR TITLE
nodeSelector in deployment needs string "true"

### DIFF
--- a/deploy/autoneg.yaml
+++ b/deploy/autoneg.yaml
@@ -305,6 +305,6 @@ spec:
       securityContext:
         runAsNonRoot: true
       nodeSelector:
-        iam.gke.io/gke-metadata-server-enabled: true
+        iam.gke.io/gke-metadata-server-enabled: "true"
       serviceAccountName: autoneg-controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
fix for Error from server (BadRequest): error when creating "deployment.yaml": Deployment in version "v1" cannot be handled as a Deployment: json: cannot unmarshal bool into Go struct field PodSpec.spec.template.spec.nodeSelector of type string