### PR TITLE
Fix deployment nodeSelector value type error

### DIFF
--- a/deploy/autoneg.yaml
+++ b/deploy/autoneg.yaml
@@ -305,6 +305,6 @@ spec:
       securityContext:
         runAsNonRoot: true
       nodeSelector:
-        iam.gke.io/gke-metadata-server-enabled: true
+        iam.gke.io/gke-metadata-server-enabled: "true"
       serviceAccountName: autoneg-controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
I tried to deploy the controller from the yaml file provided and got the following error: 

```
Error from server (BadRequest): error when creating "autoneg.yaml": Deployment in version "v1" cannot be handled as a Deployment: json: cannot unmarshal bool into Go struct field PodSpec.spec.template.spec.nodeSelector of type string
```