### PR TITLE
Add ignore changes to kubernetes service annotations

### DIFF
--- a/terraform/kubernetes/main.tf
+++ b/terraform/kubernetes/main.tf
@@ -240,6 +240,12 @@ resource "kubernetes_service" "service_autoneg_controller_manager_metrics_servic
       control-plane = "controller-manager"
     }
   }
+  lifecycle {
+    ignore_changes = [
+      metadata[0].annotations["cloud.google.com/neg"],
+      metadata[0].annotations["cloud.google.com/neg-status"],
+    ]
+  }
 }
 
 resource "kubernetes_deployment" "deployment_autoneg_controller_manager" {


### PR DESCRIPTION
Every time I plan, terraform shows diffs of annotations about neg. 
So I want it to be ignored by adding ignore_change block.

```terraform
  ~ resource "kubernetes_service" "service_autoneg_controller_manager_metrics_service" {
        id                     = "autoneg-system/autoneg-controller-manager-metrics-service"
        # (2 unchanged attributes hidden)

      ~ metadata {
          ~ annotations      = {
              ~ "cloud.google.com/neg"        = jsonencode(
                  ~ {
                      - exposed_ports = {
                          - "8443" = {}
                        }
                    }
                )
              - "cloud.google.com/neg-status" = jsonencode(
                    {
                      - network_endpoint_groups = {
                          - "8443" = "xxx"
                        }
                      - zones                   = [
                          - "xxx-a",
                          - "xxx-b",
                          - "xxx-c",
                        ]
                    }
                ) -> null
                # (3 unchanged elements hidden)
            }
            name             = "autoneg-controller-manager-metrics-service"
            # (5 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }
```

By the way, thank you for the useful solutions!