### PR TITLE
Updated Terraform example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ module "autoneg" {
   source = "github.com/GoogleCloudPlatform/gke-autoneg-controller//terraform/autoneg"
 
   project_id = "your-project-id"
+  
+  # NOTE: You may need to build your own image if you rely on features merged between releases, and do
+  # not wish to use the `latest` image.
+  controller_image = "ghcr.io/googlecloudplatform/gke-autoneg-controller/gke-autoneg-controller:v1.0.0"
 }
 ```
 


### PR DESCRIPTION
The Terraform example now informs users of the need to change the controller image when relying on features that have not yet been published to a release-versioned image (e.g., not latest).


See https://github.com/GoogleCloudPlatform/gke-autoneg-controller/issues/122.

Alternative to #123