### PR TITLE
WIP: Upgrade kube-rbac-proxy to v0.16.0

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/deploy/autoneg.yaml
+++ b/deploy/autoneg.yaml
@@ -229,7 +229,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/deploy/chart/README.md
+++ b/deploy/chart/README.md
@@ -35,7 +35,7 @@ A Helm chart for autoneg-controller-manager.
 | kube_rbac_proxy.args[1] | string | `"--upstream=http://127.0.0.1:8080/"` |  |
 | kube_rbac_proxy.args[2] | string | `"--logtostderr=true"` |  |
 | kube_rbac_proxy.args[3] | string | `"--v=10"` |  |
-| kube_rbac_proxy.image | string | `"gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0"` |  |
+| kube_rbac_proxy.image | string | `"gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0"` |  |
 | kube_rbac_proxy.name | string | `"kube-rbac-proxy"` |  |
 | kube_rbac_proxy.port | int | `8443` |  |
 | kube_rbac_proxy.securityContext.allowPrivilegeEscalation | bool | `false` |  |

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -43,7 +43,7 @@ service:
 # https://github.com/kubernetes-sigs/kubebuilder/issues/3524#issuecomment-1687893746
 kube_rbac_proxy:
   name: kube-rbac-proxy
-  image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+  image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
   securityContext:
     allowPrivilegeEscalation: false
     privileged: false

--- a/terraform/autoneg/variables.tf
+++ b/terraform/autoneg/variables.tf
@@ -34,7 +34,7 @@ variable "image_pull_policy" {
 variable "kube_rbac_proxy_image" {
   type        = string
   description = "kuber-rbac-proxy container image"
-  default     = "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0"
+  default     = "gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0"
 }
 
 variable "workload_identity" {

--- a/terraform/kubernetes/variables.tf
+++ b/terraform/kubernetes/variables.tf
@@ -33,7 +33,7 @@ variable "image_pull_policy" {
 variable "kube_rbac_proxy_image" {
   type        = string
   description = "kuber-rbac-proxy container image"
-  default     = "gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0"
+  default     = "gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0"
 }
 
 variable "service_account_email" {


### PR DESCRIPTION
Upgrade the kube-rbac-proxy version used to the latest available, in order to fix some vulnerabilities.