### PR TITLE
Upgrade Go to 1.23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.21 as builder
+FROM golang:1.23 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
This can fix the Dockerfile issue https://github.com/GoogleCloudPlatform/gke-autoneg-controller/issues/155

The github workflow is also using the same version ([link1](https://github.com/GoogleCloudPlatform/gke-autoneg-controller/blob/master/.github/workflows/go.yml#L25), [link2](https://github.com/GoogleCloudPlatform/gke-autoneg-controller/blob/master/.github/workflows/tests.yml#L30))