### PR TITLE
feat: add PodDisruptionBudget for high availability

### DIFF
--- a/deploy/chart/templates/poddisruptionbudget.yaml
+++ b/deploy/chart/templates/poddisruptionbudget.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "autoneg.fullname" . }}-pdb
+  namespace: {{ include "autoneg.namespace" . | quote }}
+  labels:
+    {{- include "autoneg.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "autoneg.selectorLabels" . | nindent 6 }}
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- else if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end }}

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -21,6 +21,14 @@ autoscaling: {}
 
 replicas: 1
 
+# Pod Disruption Budget configuration
+podDisruptionBudget:
+  # Enable or disable PDB creation
+  enabled: true
+  # Specify either minAvailable or maxUnavailable, not both
+  minAvailable: 1
+  # maxUnavailable: 1
+
 serviceAccount:
   create: true
   name: autoneg-controller-manager

--- a/terraform/kubernetes/variables.tf
+++ b/terraform/kubernetes/variables.tf
@@ -70,3 +70,17 @@ variable "priority_class_name" {
   type        = string
   default     = null
 }
+
+variable "pod_disruption_budget" {
+  description = "Pod Disruption Budget configuration"
+  type = object({
+    enabled       = bool
+    min_available = optional(number)
+    max_unavailable = optional(number)
+  })
+  default = {
+    enabled       = true
+    min_available = 1
+    max_unavailable = null
+  }
+}


### PR DESCRIPTION
feat: add PodDisruptionBudget support to prevent controller unavailability during maintenance

During GKE maintenance and rollouts, the autoneg controller was temporarily 
unavailable while application deployments were happening. The controller pod 
came up late and failed to recognize new backends, causing service disruption.

Changes include:
- Add PodDisruptionBudget template to Helm chart with configurable options
- Add PDB support to Terraform Kubernetes module with variables
- Ensure at least one controller pod remains available during voluntary disruptions
- Prevent gaps in backend discovery during cluster maintenance windows

Supports both Helm and Terraform deployment methods with consistent configuration.