### PR TITLE
Fix controller when NEG status is empty

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -105,7 +105,7 @@ type TestBackendController struct {
 	Counter int
 }
 
-func (t *TestBackendController) ReconcileBackends(AutonegStatus, AutonegStatus) error {
+func (t *TestBackendController) ReconcileBackends(context.Context, AutonegStatus, AutonegStatus) error {
 	t.Counter++
 	fmt.Print(t.Counter)
 	return nil


### PR DESCRIPTION
This commit addresses an issue where the autoneg controller would fail to reconcile backend services when the Network Endpoint Group (NEG) status annotation was empty. This scenario typically occurs if the GKE NEG controller has not yet provisioned the NEGs for a service.

The root cause was that an empty backend service name was being used in the request to the Google Cloud Compute API. This caused the API to treat the 'get' request as a 'list' request, leading to a JSON unmarshaling error due to the different response format. This error prevented the controller from removing finalizers on services marked for deletion, causing namespaces to become stuck.

The following changes have been made:

- Updated `ReconcileBackends` in `controllers/autoneg.go` to handle cases where the upsert backend service name is empty, preventing calls to `getBackendService` with an empty name.
- Added `context.Context` propagation through `ReconcileBackends`.
- Added a new unit test, `TestReconcileBackendsDeletionWithEmptyNEGStatus`, in `controllers/autoneg_test.go` to specifically cover the error scenario.
- Updated function signatures and calls in `controllers/service_controller.go` and `controllers/suite_test.go` to align with the changes in the `BackendController` interface.


Closes #164