### PR TITLE
Fix annotations merge reference in Helm chart for service account

### DIFF
--- a/deploy/chart/templates/service-account.yaml
+++ b/deploy/chart/templates/service-account.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ include "autoneg.namespace" . | quote }}
   labels: {{- include "autoneg.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
-  {{- $annotations := merge .Values.annotations .Values.serviceAccount.annotations -}}
+  {{- $annotations := merge .Values.serviceAccount.annotations .Values.annotations -}}
   {{- with $annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
The left most value is the "destination", so adding annotations for the service account results in being incorrectly added to the deployment.