### PR TITLE
Support preference field on backends

### DIFF
--- a/controllers/autoneg.go
+++ b/controllers/autoneg.go
@@ -112,6 +112,7 @@ func (s AutonegStatus) Backend(name string, port string, group string) compute.B
 				}
 			}),
 			CapacityScaler: capacityScaler,
+			Preference:     cfg.Preference,
 		}
 	} else if cfg.Rate > 0 {
 		return compute.Backend{
@@ -119,6 +120,7 @@ func (s AutonegStatus) Backend(name string, port string, group string) compute.B
 			BalancingMode:      "RATE",
 			MaxRatePerEndpoint: float64(cfg.Rate),
 			CapacityScaler:     capacityScaler,
+			Preference:         cfg.Preference,
 		}
 	} else {
 		return compute.Backend{
@@ -126,6 +128,7 @@ func (s AutonegStatus) Backend(name string, port string, group string) compute.B
 			BalancingMode:             "CONNECTION",
 			MaxConnectionsPerEndpoint: int64(cfg.Connections),
 			CapacityScaler:            capacityScaler,
+			Preference:                cfg.Preference,
 		}
 	}
 }
@@ -617,6 +620,10 @@ func validateConfig(config AutonegConfig) error {
 				if !hasDryRun && len(cfg.CustomMetrics) > 2 {
 					return fmt.Errorf("too many custom_metrics for backend %q must be at most 2, but was %q; see https://docs.cloud.google.com/load-balancing/docs/https/applb-custom-metrics#metrics-limits-requirements for details", cfg.Name, len(cfg.CustomMetrics))
 				}
+			}
+
+			if cfg.Preference != "" && cfg.Preference != "DEFAULT" && cfg.Preference != "PREFERRED" {
+				return fmt.Errorf("preference for backend %q must be DEFAULT or PREFERRED, but was %q", cfg.Name, cfg.Preference)
 			}
 		}
 	}

--- a/controllers/autoneg_test.go
+++ b/controllers/autoneg_test.go
@@ -393,6 +393,7 @@ func TestValidateNewConfig(t *testing.T) {
 		err                    bool
 		expectedCapacityScaler float64
 		expectedBalancingMode  string
+		expectedPreference     string
 	}{
 		{
 			name:                   "default config",
@@ -606,6 +607,60 @@ func TestValidateNewConfig(t *testing.T) {
 			expectedCapacityScaler: 0.42,
 			expectedBalancingMode:  "CUSTOM_METRICS",
 		},
+		{
+			name: "valid preference PREFERRED",
+			config: AutonegConfig{
+				BackendServices: map[string]map[string]AutonegNEGConfig{
+					"80": {
+						"http-be": {
+							Name:       "http-be",
+							Rate:       100,
+							Preference: "PREFERRED",
+						},
+					},
+				},
+			},
+			err:                    false,
+			expectedCapacityScaler: 1,
+			expectedBalancingMode:  "RATE",
+			expectedPreference:     "PREFERRED",
+		},
+		{
+			name: "valid preference DEFAULT",
+			config: AutonegConfig{
+				BackendServices: map[string]map[string]AutonegNEGConfig{
+					"80": {
+						"http-be": {
+							Name:       "http-be",
+							Rate:       100,
+							Preference: "DEFAULT",
+						},
+					},
+				},
+			},
+			err:                    false,
+			expectedCapacityScaler: 1,
+			expectedBalancingMode:  "RATE",
+			expectedPreference:     "DEFAULT",
+		},
+		{
+			name: "invalid preference",
+			config: AutonegConfig{
+				BackendServices: map[string]map[string]AutonegNEGConfig{
+					"80": {
+						"http-be": {
+							Name:       "http-be",
+							Rate:       100,
+							Preference: "INVALID",
+						},
+					},
+				},
+			},
+			err:                    true,
+			expectedCapacityScaler: 1,
+			expectedBalancingMode:  "RATE",
+			expectedPreference:     "INVALID",
+		},
 	}
 
 	for _, ct := range tests {
@@ -633,6 +688,10 @@ func TestValidateNewConfig(t *testing.T) {
 		if beConfig.BalancingMode != ct.expectedBalancingMode {
 			t.Errorf("Set %q: expected balacing mode %q, got: %q", ct.name, ct.expectedBalancingMode, beConfig.BalancingMode)
 		}
+
+		if beConfig.Preference != ct.expectedPreference {
+			t.Errorf("Set %q: expected preference %q, got: %q", ct.name, ct.expectedPreference, beConfig.Preference)
+		}
 	}
 }
 
@@ -641,6 +700,7 @@ func relevantCopy(a compute.Backend) compute.Backend {
 	b.Group = a.Group
 	b.MaxRatePerEndpoint = a.MaxRatePerEndpoint
 	b.MaxConnectionsPerEndpoint = a.MaxConnectionsPerEndpoint
+	b.Preference = a.Preference
 	if len(a.CustomMetrics) > 0 {
 		b.CustomMetrics = slices.Collect(func(yield func(*compute.BackendCustomMetric) bool) {
 			for _, acm := range a.CustomMetrics {

--- a/controllers/types.go
+++ b/controllers/types.go
@@ -74,6 +74,7 @@ type AutonegNEGConfig struct {
 	CustomMetrics   []AutonegCustomMetric `json:"custom_metrics,omitempty"`
 	InitialCapacity *StringOrInt          `json:"initial_capacity,omitempty"`
 	CapacityScaler  *StringOrInt          `json:"capacity_scaler,omitempty"`
+	Preference      string                `json:"preference,omitempty"`
 }
 
 // AutonegSyncConfig specifies additional configuration which to sync


### PR DESCRIPTION
Adds support for the GCP backend preference field (DEFAULT or PREFERRED) in the autoneg NEG configuration. This lets operators mark certain backends as preferred, with traffic overflowing to non-preferred backends only when preferred are full or unhealthy.

The field is a pure passthrough from the annotation config to compute.Backend.Preference - no transformation or new logic. Validation rejects values other than DEFAULT, PREFERRED, or empty.

Ref: https://cloud.google.com/load-balancing/docs/service-lb-policy\#preferred-backends
